### PR TITLE
feat(runtime): lambda infrastructure vs microservice for compiler

### DIFF
--- a/apps/sandbox/app/app.tsx
+++ b/apps/sandbox/app/app.tsx
@@ -26,7 +26,7 @@ export async function clientLoader() {
     const fileMap: FileMap = {};
     for (const file of fileTree) {
       try {
-        const fileData = await downloadFile(file)
+        const fileData = await downloadFile(file.id)
         fileMap[file.id] = fileData;
       } catch (error) {
         console.error(`Failed to download file ${file.id}:`, error);

--- a/apps/sketchscript-core/src/Main.hs
+++ b/apps/sketchscript-core/src/Main.hs
@@ -2,15 +2,10 @@ module Main where
 
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
-import Data.Void (Void)
-import Parser.Script (parseScript)
-import Text.Megaparsec
-import Types (Parser)
+import Parser.Script (parseSketchScript)
 
 main :: IO ()
 main = do
   putStrLn "Enter your script:"
   input <- TIO.getContents
-  case parse parseScript "<stdin>" (T.unpack input) of
-    Left err -> putStrLn (errorBundlePretty err)
-    Right ast -> print ast
+  print $ parseSketchScript (T.unpack input)

--- a/apps/sketchscript-core/src/Parser/Script.hs
+++ b/apps/sketchscript-core/src/Parser/Script.hs
@@ -1,7 +1,8 @@
-module Parser.Script (parseScript) where
+module Parser.Script (parseSketchScript) where
 
 import Parser.Element (parseElements)
 import SketchScriptTypes (Element)
+import Text.Megaparsec (errorBundlePretty, parse)
 import qualified Text.Megaparsec.Char as TMC
 import Types (Parser)
 
@@ -9,3 +10,9 @@ parseScript :: Parser [Element]
 parseScript = do
   TMC.space
   parseElements 1
+
+parseSketchScript :: String -> Either String [Element]
+parseSketchScript input =
+  case parse parseScript "sketch-script" input of
+    Left err -> Left (errorBundlePretty err)
+    Right ast -> Right ast

--- a/apps/sketchscript-runtime/server/Main.hs
+++ b/apps/sketchscript-runtime/server/Main.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main where
+
+import Amazonka (ToBody (toBody), discover, newEnv, send)
+import Amazonka.Data.Body (ResponseBody (..))
+import Amazonka.S3 (BucketName (BucketName), ObjectKey (ObjectKey), newGetObject, newPutObject)
+import Amazonka.S3.GetObject (getObjectResponse_body)
+import CodeGenerators.Element (genElement)
+import Conduit
+import Configuration.Dotenv (defaultConfig, loadFile)
+import Control.Exception (SomeException, try)
+import Control.Lens
+import Control.Monad.Trans.Except (ExceptT, runExceptT, throwE)
+import Data.Aeson (FromJSON)
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.Conduit.Combinators as C
+import Data.Generics.Labels ()
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import Debug.Trace (traceM)
+import GHC.Generics
+import Network.HTTP.Types (status200)
+import Network.HTTP.Types.Status (internalServerError500)
+import Network.Wai.Middleware.AddHeaders (addHeaders)
+import Parser.Script
+import System.Environment (getEnv)
+import Web.Scotty (ScottyM, function, jsonData, options, post, scotty, status, text)
+import Web.Scotty.Trans (middleware)
+
+data DownloadReq = DownloadReq
+  { key :: T.Text
+  }
+  deriving (Generic, FromJSON)
+
+main :: IO ()
+main = do
+  _ <- loadFile defaultConfig
+  bucketName <- getEnv "S3_BUCKET_NAME"
+  origin <- getEnv "CORS_ALLOWED_ORIGIN"
+  traceM origin
+  scotty 8081 $ do
+    middleware $
+      addHeaders
+        [ ("Access-Control-Allow-Origin", BS.pack origin),
+          ("Access-Control-Allow-Headers", "Content-Type, Authorization"),
+          ("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+        ]
+    options (function (const (Just []))) $ do
+      status status200
+      text ""
+    compileEndpoint (BucketName (T.pack bucketName))
+
+compileEndpoint :: BucketName -> ScottyM ()
+compileEndpoint defaultBucket = do
+  post "/compile" $ do
+    DownloadReq {..} <- jsonData
+    let objectKey = ObjectKey key
+    result <- liftIO $ runExceptT $ do
+      content <- downloadFile defaultBucket objectKey
+      ast <- case parseSketchScript (T.unpack content) of
+        Left err -> throwE err
+        Right ast -> return ast
+      uploadFile defaultBucket key (concatMap genElement ast)
+    case result of
+      Left err -> do
+        status internalServerError500
+        text $ TL.pack err
+      Right _ -> text "Successfuly compiled and updated project"
+
+downloadFile :: BucketName -> ObjectKey -> ExceptT String IO T.Text
+downloadFile b k = do
+  env <- newEnv discover
+  result <- liftIO $ try $ runResourceT $ do
+    rs <- send env (newGetObject b k)
+    runConduit $
+      body (rs ^. getObjectResponse_body)
+        .| C.decodeUtf8
+        .| C.fold
+  case result of
+    Left (e :: SomeException) -> throwE $ "Failed to download file: " ++ show e
+    Right txt -> return txt
+
+uploadFile :: BucketName -> T.Text -> String -> ExceptT String IO T.Text
+uploadFile b k s = do
+  env <- newEnv discover
+  let newKey = k <> ".html"
+  let body = toBody (T.pack s)
+  result <- liftIO $ try $ runResourceT $ do
+    _ <- send env (newPutObject b (ObjectKey newKey) body)
+    return ()
+  case result of
+    Left (e :: SomeException) -> throwE $ "Failed to upload file: " ++ show e
+    Right _ -> return "Successfully uploaded file"

--- a/apps/sketchscript-runtime/sketchscript-runtime.cabal
+++ b/apps/sketchscript-runtime/sketchscript-runtime.cabal
@@ -17,17 +17,63 @@ extra-doc-files: CHANGELOG.md
 common warnings
   ghc-options: -Wall
 
+executable sketchscript-runtime
+  -- Import common warning flags.
+  import: warnings
+  -- .hs or .lhs file containing the Main module.
+  main-is: Main.hs
+  -- Modules included in this executable, other than Main.
+  -- other-modules:
+  -- LANGUAGE extensions used by modules in this package.
+  -- other-extensions:
+  -- Other library packages from which modules are imported.
+  build-depends:
+    aeson,
+    amazonka >=2.0 && <2.1,
+    amazonka-core,
+    amazonka-s3,
+    base ^>=4.18.3.0,
+    base >=4.18.3.0 && <5,
+    bytestring,
+    conduit,
+    conduit-extra,
+    dotenv,
+    generic-lens,
+    lens,
+    scotty,
+    sketchscript-core,
+    sketchscript-runtime,
+    http-types,
+    transformers,
+    text,
+    wai-extra,
+
+  -- Directories containing source files.
+  hs-source-dirs: server
+  -- Base language which the package is written in.
+  default-language: Haskell2010
+
 library
   import: warnings
-  other-modules:
+  exposed-modules:
     CodeGenerators.Element
+
+  other-modules:
     CodeGenerators.Utils
     CodeGenerators.Widget
 
   -- other-extensions:
   build-depends:
+    aeson,
+    amazonka >=2.0 && <2.1,
+    amazonka-s3,
     base ^>=4.18.3.0,
+    bytestring,
+    lens,
+    scotty,
     sketchscript-core,
+    text,
+    wai-extra,
 
   hs-source-dirs: src
   default-language: Haskell2010
@@ -40,6 +86,4 @@ test-suite sketchscript-runtime-test
   type: exitcode-stdio-1.0
   hs-source-dirs: test
   main-is: Main.hs
-  build-depends:
-    base ^>=4.18.3.0,
-    sketchscript-runtime,
+  build-depends: base ^>=4.18.3.0

--- a/apps/sketchscript-runtime/src/CodeGenerators/Element.hs
+++ b/apps/sketchscript-runtime/src/CodeGenerators/Element.hs
@@ -10,9 +10,8 @@ genElement (ElementWidget x) = genWidget x
 
 genContainer :: Container -> String
 genContainer (Container Box sizing styles children) =
-  "<div "
-    ++ genCSS sizing styles
-    ++ ">\n"
+  "<div class=\""
+    ++ genTailwindContainerClasses sizing styles children
+    ++ "\">\n"
     ++ concatMap genElement children
-    ++ "\n"
-    ++ "</div>"
+    ++ "\n</div>"

--- a/apps/sketchscript-runtime/src/CodeGenerators/Utils.hs
+++ b/apps/sketchscript-runtime/src/CodeGenerators/Utils.hs
@@ -1,24 +1,51 @@
-module CodeGenerators.Utils (genCSS) where
+module CodeGenerators.Utils (genTailwindClasses, genTailwindContainerClasses) where
 
 import Data.Maybe (fromMaybe)
 import SketchScriptTypes
 
 genSizing :: Sizing -> String
-genSizing (Sizing x) = "width: " ++ show (fromMaybe 1 x * 100) ++ "%;"
-
-genStyles :: Style -> String
-genStyles (Flex justify) =
-  "display: flex; justify-content: " ++ genJustify justify ++ ";"
-genStyles (Grid (ColsAndRows c r)) =
-  "display: grid; grid-template-columns: repeat(" ++ show c ++ ", 1fr); grid-template-rows: repeat(" ++ show r ++ ", 1fr);"
+genSizing (Sizing x) =
+  let percent = fromMaybe 1 x * 100
+   in "w-[" ++ show percent ++ "%]"
 
 genJustify :: Justify -> String
-genJustify Start = "flex-start"
-genJustify Center = "center"
-genJustify End = "flex-end"
-genJustify SpaceBetween = "space-between"
-genJustify SpaceAround = "space-around"
+genJustify Start = "justify-start"
+genJustify Center = "justify-center"
+genJustify End = "justify-end"
+genJustify SpaceBetween = "justify-between"
+genJustify SpaceAround = "justify-around"
 
-genCSS :: Sizing -> Style -> String
-genCSS sizing styles =
-  "style=\"" ++ genSizing sizing ++ " " ++ genStyles styles ++ "\""
+genLayoutStyle :: Style -> String
+genLayoutStyle (Flex j) = "flex " ++ genJustify j
+genLayoutStyle (Grid (ColsAndRows c r)) =
+  "grid grid-cols-" ++ show c ++ " grid-rows-" ++ show r
+
+genWidgetBaseStyle :: WidgetType -> String
+genWidgetBaseStyle Button =
+  "bg-red-400 px-4 py-2 rounded text-center"
+genWidgetBaseStyle InputBox = "px-2 py-1 bg-blue-200"
+genWidgetBaseStyle TextField = "p-2 text-gray-200"
+genWidgetBaseStyle Image = "object-contain"
+
+genPlaceholderIfEmpty :: WidgetType -> String
+genPlaceholderIfEmpty Image = "bg-gray-100"
+genPlaceholderIfEmpty _ = "bg-gray-100 text-gray-500"
+
+genTailwindClasses :: WidgetType -> Sizing -> Style -> String
+genTailwindClasses widgetType sizing style =
+  unwords
+    [ genSizing sizing,
+      genLayoutStyle style,
+      genWidgetBaseStyle widgetType,
+      "border border-black",
+      genPlaceholderIfEmpty widgetType
+    ]
+
+genTailwindContainerClasses :: Sizing -> Style -> [Element] -> String
+genTailwindContainerClasses sizing style children =
+  unwords
+    [ genSizing sizing,
+      genLayoutStyle style,
+      "border border-black",
+      if null children then "bg-gray-100" else ""
+    ]

--- a/apps/sketchscript-runtime/src/CodeGenerators/Widget.hs
+++ b/apps/sketchscript-runtime/src/CodeGenerators/Widget.hs
@@ -6,15 +6,14 @@ import SketchScriptTypes
 
 genWidget :: Widget -> String
 genWidget (Widget widgetType sizing content) =
-  genWidgetType widgetType content (genCSS sizing (Flex Start))
+  genWidgetType widgetType content (genTailwindClasses widgetType sizing (Flex Start))
 
 genWidgetType :: WidgetType -> Content -> String -> String
-genWidgetType Button (Content mText) style =
-  "<button " ++ style ++ ">" ++ fromMaybe "" mText ++ "</button>"
-genWidgetType InputBox (Content _) style =
-  "<input type=\"text\" " ++ style ++ " />"
-genWidgetType TextField (Content mText) style =
-  "<p " ++ style ++ ">" ++ fromMaybe "" mText ++ "</p>"
-genWidgetType Image (Content _mUrl) style =
-  -- url is not used here
-  "<img alt=\"Image\" " ++ style ++ " />"
+genWidgetType Button (Content mText) classes =
+  "<button class=\"" ++ classes ++ "\">" ++ fromMaybe "Button" mText ++ "</button>"
+genWidgetType InputBox (Content mText) classes =
+  "<input disabled type=\"text\" class=\"" ++ classes ++ "\" placeholder=\"" ++ fromMaybe "" mText ++ "\" />"
+genWidgetType TextField (Content mText) classes =
+  "<p class=\"" ++ classes ++ "\">" ++ fromMaybe "Text" mText ++ "</p>"
+genWidgetType Image (Content _mUrl) classes =
+  "<img alt=\"Image\" class=\"" ++ classes ++ "\" />"

--- a/libs/sandbox/features/code-editor/canvas/ui/index.tsx
+++ b/libs/sandbox/features/code-editor/canvas/ui/index.tsx
@@ -1,13 +1,19 @@
-import DOMPurify from 'isomorphic-dompurify'
+import { useState } from 'react';
+import { pollDownloadFile } from '../../../../api/files';
 
 type CanvasProps = {
-  htmlOutput: string;
+  currentFile: string;
 };
-export function Canvas({ htmlOutput }: CanvasProps) {
-  const safeHtml = DOMPurify.sanitize(htmlOutput);
+export function Canvas({ currentFile }: CanvasProps) {
+
+  const [htmlOutput, setHtmlOutput] = useState('Loading...');
+  pollDownloadFile(currentFile, setHtmlOutput)
+
+  // const sampleHtml = '<div class="p-4 bg-blue-100 text-blue-900 rounded shadow">Hello from Tailwind-styled HTML!</div>';
+
   return (
     <div className="w-1/2 p-4 overflow-auto text-black bg-white">
-      <div dangerouslySetInnerHTML={{ __html: safeHtml }} />
+      <div dangerouslySetInnerHTML={{ __html: htmlOutput }} />
     </div>
   )
 }

--- a/libs/sandbox/features/code-editor/ui/presenter.tsx
+++ b/libs/sandbox/features/code-editor/ui/presenter.tsx
@@ -9,18 +9,18 @@ import { FileTreeNode } from '../../../api/files';
 
 export function CodeEditor() {
   const { fileTree, fileMap } = useLoaderData() as { fileTree: FileTreeNode[], fileMap: FileMap };
-
   const treeRef = useRef(null)
   const [treeWidth, setTreeWidth] = useState(210)
   const [allFiles, setAllFiles] = useState<FileMap>(fileMap)
   const [currentFile, setCurrentFile] = useState<string>(fileTree[0]?.id || '');
 
 
+
   return (
     <div className="flex h-screen p-2 overflow-hidden max-w-screen">
       <FileTree treeRef={treeRef} treeWidth={treeWidth} setTreeWidth={setTreeWidth} setCurrentFile={setCurrentFile} />
       <MyEditor allFiles={allFiles} setAllFiles={setAllFiles} currentNode={currentFile} />
-      <Canvas htmlOutput={`<div className='text-lg'><h1>Hello world!</h1><p>This is your rendered DSL.</p></div>`} />
+      <Canvas currentFile={currentFile} />
     </div>
   )
 }

--- a/libs/sandbox/shared/axiosInstance.ts
+++ b/libs/sandbox/shared/axiosInstance.ts
@@ -10,3 +10,8 @@ export const axiosInstance = axios.create({
   timeout: 10000,
 });
 
+export const axiosInstanceCompiler = axios.create({
+  baseURL: isBrowser
+    ? import.meta.env.VITE_PUBLIC_API_BASE_COMPILER
+    : process.env.API_BASE_COMPILER,
+});


### PR DESCRIPTION
## Summary by Sourcery

Generate Tailwind-based styling in the Haskell runtime, introduce a standalone compile service for on-demand HTML generation and S3 uploads, and update the frontend to upload files, trigger compilation, and poll for rendered output.

New Features:
- Generate Tailwind CSS utility classes for widgets and containers in the runtime code generator
- Expose a new `/compile` microservice endpoint to compile SketchScript files and upload HTML output to S3
- Implement polling in the React Canvas component to fetch compiled HTML from S3 asynchronously
- Add a dedicated axios instance for compiler API calls and invoke compilation after file uploads

Bug Fixes:
- Add status checks after uploading to presigned URL to catch upload failures

Enhancements:
- Replace inline style strings with Tailwind utility classes across Haskell generators
- Refactor parser interface to use a `parseSketchScript` helper returning `Either String`
- Switch `FileId` representation from `UUID` to plain `Text` in the backend S3 API
- Refactor the CodeEditor presenter to manage `currentFile` state and wire it into the Canvas component